### PR TITLE
Add tenancy and AI workflow tests

### DIFF
--- a/tests/Feature/AiRunBatchCommandTest.php
+++ b/tests/Feature/AiRunBatchCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\AiArticleService;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class AiRunBatchCommandTest extends TestCase
+{
+    public function test_command_outputs_batch_completed(): void
+    {
+        $this->app->bind(AiArticleService::class, fn() => new class extends AiArticleService {
+            public function __construct() {}
+            public function handle(\App\Models\AiArticleJob $job, int $from = 1, int $to = 7): void {}
+        });
+
+        Artisan::call('ai:run-batch', ['--limit' => 0]);
+
+        $this->assertStringContainsString('Batch completed', Artisan::output());
+    }
+}

--- a/tests/Feature/TenancyMiddlewareTest.php
+++ b/tests/Feature/TenancyMiddlewareTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Stancl\Tenancy\Database\Models\Tenant;
+use Stancl\Tenancy\Database\Models\Domain;
+use Tests\TestCase;
+
+class TenancyMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_central_domain_is_blocked_from_tenant_routes(): void
+    {
+        Tenant::create(['id' => 'acme']);
+        Domain::create(['domain' => 'acme.localhost', 'tenant_id' => 'acme']);
+
+        $response = $this->get('http://localhost/dashboard');
+
+        $response->assertForbidden();
+    }
+
+    public function test_tenant_domain_allows_access_to_tenant_routes(): void
+    {
+        Tenant::create(['id' => 'acme']);
+        Domain::create(['domain' => 'acme.localhost', 'tenant_id' => 'acme']);
+
+        $response = $this->get('http://acme.localhost/dashboard');
+
+        $response->assertStatus(302); // redirected to login
+    }
+}

--- a/tests/Unit/AiArticleHelpersTest.php
+++ b/tests/Unit/AiArticleHelpersTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\Concerns\HasAiArticleHelpers;
+use PHPUnit\Framework\TestCase;
+
+class AiArticleHelpersTest extends TestCase
+{
+    private object $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new class {
+            use HasAiArticleHelpers;
+        };
+    }
+
+    public function test_best_html_returns_first_available_field(): void
+    {
+        $steps = [
+            'step6' => ['html' => 'six'],
+            'step5' => ['html' => 'five'],
+            'step4' => ['html' => 'four'],
+        ];
+
+        $this->assertSame('six', $this->helper->bestHtml($steps));
+    }
+
+    public function test_best_html_returns_empty_string_if_none_present(): void
+    {
+        $this->assertSame('', $this->helper->bestHtml([]));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for tenancy routing and middleware
- add tests for AI article helpers and the `ai:run-batch` command

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847159fe178832eba6a0da441905943