### PR TITLE
Add Laravel bootstrap method to TestCase

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,20 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
+use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Console\Kernel;
+
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /**
+     * Create the application.
+     */
+    public function createApplication(): Application
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
 }


### PR DESCRIPTION
## Summary
- allow PHPUnit to boot the application by implementing `createApplication()`

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c66abf0e8832eb853b1e336c7e873