### PR TITLE
Update SerpAPI configuration usage

### DIFF
--- a/app/Services/AiArticleService.php
+++ b/app/Services/AiArticleService.php
@@ -74,7 +74,7 @@ class AiArticleService
             'engine'    => 'google',
             'q'         => $kw,
             'hl'        => 'it',
-            'api_key'   => env('SERP_API_KEY'),
+            'api_key'   => config('services.serp.key'),
         ]);
     }
 

--- a/config/services.php
+++ b/config/services.php
@@ -28,6 +28,10 @@ return [
         'key' => env('RESEND_KEY'),
     ],
 
+    'serp' => [
+        'key' => env('SERP_API_KEY'),
+    ],
+
     'slack' => [
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),


### PR DESCRIPTION
## Summary
- register new `serp` service key in `config/services.php`
- use `config('services.serp.key')` when making SERP API calls

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c66b5bf54832e9a6d1c43fc59e83f