### PR TITLE
Add Search and OpenAI bindings

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,9 @@ namespace App\Providers;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use SerpApi\Search;
+use OpenAI\Client as OpenAIClient;
+use OpenAI;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -12,7 +15,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(Search::class, function (): Search {
+            return new Search(['api_key' => config('services.serp.key')]);
+        });
+
+        $this->app->singleton(OpenAIClient::class, function (): OpenAIClient {
+            return OpenAI::client(config('services.openai.key'));
+        });
     }
 
     /**

--- a/app/Services/AiArticleService.php
+++ b/app/Services/AiArticleService.php
@@ -74,7 +74,6 @@ class AiArticleService
             'engine'    => 'google',
             'q'         => $kw,
             'hl'        => 'it',
-            'api_key'   => env('SERP_API_KEY'),
         ]);
     }
 

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,12 @@ return [
         ],
     ],
 
+    'serp' => [
+        'key' => env('SERP_API_KEY'),
+    ],
+
+    'openai' => [
+        'key' => env('OPENAI_API_KEY'),
+    ],
+
 ];


### PR DESCRIPTION
## Summary
- configure `serp` and `openai` credentials in `config/services.php`
- bind `SerpApi\Search` and `OpenAI\Client` in `AppServiceProvider`
- rely on injected key in `AiArticleService`

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c68bcde9c832eaeb46027da7d4b7a