### PR TITLE
Implement AI JSON schema generator

### DIFF
--- a/app/Jobs/GenerateJsonSchema.php
+++ b/app/Jobs/GenerateJsonSchema.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\JsonSchemaResult;
+use App\Services\TokenService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+
+class GenerateJsonSchema implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public JsonSchemaResult $result,
+        public string $serialKey = '',
+        public string $businessInfo = ''
+    ) {
+    }
+
+    public function handle(TokenService $tokens): void
+    {
+        $scrape = Http::post(
+            'https://api.clementeteodonno.it/wp-json/myplugin/v1/scrape-url?user_key=' . $this->serialKey,
+            ['url' => $this->result->url]
+        )->body();
+
+        $prompt = [
+            'prompt_text_system' => $this->businessInfo,
+            'prompt_text'       => '**URL pagina**: ' . $this->result->url . "\n\n**Contenuto Pagina:**\n" . $scrape,
+            'chatgpt_model'     => 'gpt-4-turbo',
+        ];
+
+        $response = Http::post(
+            'https://api.clementeteodonno.it/wp-json/myplugin/v1/generate-category-description?user_key=' . $this->serialKey,
+            $prompt
+        )->json();
+
+        $schema = $response['result']['choices'][0]['message']['content'] ?? '';
+        $schema = str_replace('```', '', $schema);
+
+        $this->result->update(['schema' => $schema]);
+
+        $tokens->record(strlen($schema), 'json-schema');
+    }
+}

--- a/app/Livewire/AiGenerateJsonSchema.php
+++ b/app/Livewire/AiGenerateJsonSchema.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use App\Models\JsonSchemaResult;
+use App\Jobs\GenerateJsonSchema;
+
+class AiGenerateJsonSchema extends Component
+{
+    use WithFileUploads;
+
+    public $sitemap;
+    public $serialKey = '';
+    public $businessInfo = '';
+
+    protected $rules = [
+        'sitemap' => 'required|file|mimes:xml',
+    ];
+
+    public function uploadSitemap(): void
+    {
+        $this->validate();
+        $xml = simplexml_load_string($this->sitemap->get());
+        foreach ($xml->url as $url) {
+            JsonSchemaResult::firstOrCreate([
+                'url' => (string) $url->loc,
+            ]);
+        }
+    }
+
+    public function generate(): void
+    {
+        $results = JsonSchemaResult::whereNull('schema')->get();
+        foreach ($results as $result) {
+            GenerateJsonSchema::dispatch($result, $this->serialKey, $this->businessInfo);
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        JsonSchemaResult::whereKey($id)->delete();
+    }
+
+    public function render()
+    {
+        return view('livewire.ai-generate-json-schema', [
+            'results' => JsonSchemaResult::all(),
+        ]);
+    }
+}

--- a/app/Models/JsonSchemaResult.php
+++ b/app/Models/JsonSchemaResult.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class JsonSchemaResult extends Model
+{
+    protected $fillable = [
+        'url',
+        'schema',
+    ];
+}

--- a/app/Models/TokenLog.php
+++ b/app/Models/TokenLog.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TokenLog extends Model
+{
+    protected $fillable = [
+        'tokens',
+        'action',
+    ];
+}

--- a/app/Services/TokenService.php
+++ b/app/Services/TokenService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TokenLog;
+
+class TokenService
+{
+    public function record(int $tokens, ?string $action = null): void
+    {
+        TokenLog::create([
+            'tokens' => $tokens,
+            'action' => $action,
+        ]);
+    }
+}

--- a/database/migrations/2025_05_24_000000_create_json_schema_results_table.php
+++ b/database/migrations/2025_05_24_000000_create_json_schema_results_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('json_schema_results', function (Blueprint $table) {
+            $table->id();
+            $table->string('url')->unique();
+            $table->longText('schema')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('json_schema_results');
+    }
+};

--- a/database/migrations/2025_05_24_000001_create_token_logs_table.php
+++ b/database/migrations/2025_05_24_000001_create_token_logs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('token_logs', function (Blueprint $table) {
+            $table->id();
+            $table->integer('tokens');
+            $table->string('action')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('token_logs');
+    }
+};

--- a/resources/views/livewire/ai-generate-json-schema.blade.php
+++ b/resources/views/livewire/ai-generate-json-schema.blade.php
@@ -1,0 +1,35 @@
+<div class="p-6">
+    <form wire:submit.prevent="uploadSitemap" class="mb-4">
+        <input type="file" wire:model="sitemap" accept=".xml">
+        <button type="submit" class="ml-2 px-4 py-2 bg-blue-500 text-white">Upload Sitemap</button>
+    </form>
+
+    <div class="mb-4">
+        <input type="text" wire:model="serialKey" placeholder="Serial key" class="border p-2 mr-2">
+        <input type="text" wire:model="businessInfo" placeholder="Business info" class="border p-2">
+        <button wire:click="generate" class="ml-2 px-4 py-2 bg-green-500 text-white">Generate Schema</button>
+    </div>
+
+    <table class="w-full text-left border">
+        <thead>
+            <tr>
+                <th class="border px-2">URL</th>
+                <th class="border px-2">Schema</th>
+                <th class="border px-2">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($results as $result)
+            <tr>
+                <td class="border px-2">{{ $result->url }}</td>
+                <td class="border px-2">
+                    <textarea class="w-full" rows="5" readonly>{{ $result->schema }}</textarea>
+                </td>
+                <td class="border px-2">
+                    <button wire:click="delete({{ $result->id }})" class="px-2 py-1 bg-red-500 text-white">Delete</button>
+                </td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -5,4 +5,5 @@ use App\Http\Controllers\DashboardController;
 Route::middleware(['web','auth:sanctum','verified'])->group(function () {
     Route::get('/dashboard', DashboardController::class)->name('dashboard');
     Route::redirect('/', '/dashboard');
+    Route::get('/ai-json-schema', \App\Livewire\AiGenerateJsonSchema::class)->name('ai-json-schema');
 });

--- a/tests/Feature/JsonSchemaGenerationTest.php
+++ b/tests/Feature/JsonSchemaGenerationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\GenerateJsonSchema;
+use App\Livewire\AiGenerateJsonSchema;
+use App\Models\JsonSchemaResult;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class JsonSchemaGenerationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sitemap_upload_creates_results(): void
+    {
+        $xml = '<?xml version="1.0"?><urlset><url><loc>https://example.com/a</loc></url><url><loc>https://example.com/b</loc></url></urlset>';
+        $file = UploadedFile::fake()->createWithContent('sitemap.xml', $xml);
+
+        Livewire::test(AiGenerateJsonSchema::class)
+            ->set('sitemap', $file)
+            ->call('uploadSitemap');
+
+        $this->assertEquals([
+            'https://example.com/a',
+            'https://example.com/b',
+        ], JsonSchemaResult::pluck('url')->toArray());
+    }
+
+    public function test_job_generates_schema_and_tracks_tokens(): void
+    {
+        Http::fake([
+            '*/scrape-url*' => Http::response('content'),
+            '*/generate-category-description*' => Http::response([
+                'result' => [
+                    'choices' => [
+                        ['message' => ['content' => '```schema```']],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $result = JsonSchemaResult::create(['url' => 'https://example.com/a']);
+
+        GenerateJsonSchema::dispatchSync($result, 'key', 'info');
+
+        $this->assertEquals('schema', $result->fresh()->schema);
+        $this->assertDatabaseCount('token_logs', 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add GenerateJsonSchema queue job
- create Livewire component to upload sitemap and launch jobs
- track token usage via TokenService
- store schema results and token logs via migrations
- expose tool under tenant route `/ai-json-schema`
- add feature test covering upload and generation flows

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6e9081f4832eb4c51a1e1e327aa1