### PR TITLE
feat: add negative keyword migrations and models

### DIFF
--- a/app/Models/CampaignStrategy.php
+++ b/app/Models/CampaignStrategy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CampaignStrategy extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'google_campaign_id',
+        'campaign_name',
+        'strategy',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function negativeKeywords(): HasMany
+    {
+        return $this->hasMany(NegativeKeyword::class);
+    }
+}

--- a/app/Models/GoogleAdsToken.php
+++ b/app/Models/GoogleAdsToken.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class GoogleAdsToken extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'access_token',
+        'refresh_token',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'access_token' => 'array',
+        'expires_at'   => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/NegativeKeyword.php
+++ b/app/Models/NegativeKeyword.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class NegativeKeyword extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'campaign_strategy_id',
+        'adgroup_name',
+        'keyword',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(CampaignStrategy::class, 'campaign_strategy_id');
+    }
+}

--- a/database/migrations/2025_06_14_000000_create_google_ads_tokens_table.php
+++ b/database/migrations/2025_06_14_000000_create_google_ads_tokens_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('google_ads_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->json('access_token');
+            $table->string('refresh_token');
+            $table->timestamp('expires_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('google_ads_tokens');
+    }
+};

--- a/database/migrations/2025_06_14_000100_create_campaign_strategies_table.php
+++ b/database/migrations/2025_06_14_000100_create_campaign_strategies_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('campaign_strategies', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('google_campaign_id')->index();
+            $table->string('campaign_name');
+            $table->text('strategy')->nullable();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'google_campaign_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('campaign_strategies');
+    }
+};

--- a/database/migrations/2025_06_14_000200_create_negative_keywords_table.php
+++ b/database/migrations/2025_06_14_000200_create_negative_keywords_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('negative_keywords', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('campaign_strategy_id')
+                  ->constrained('campaign_strategies')
+                  ->cascadeOnDelete();
+            $table->string('adgroup_name')->nullable();
+            $table->string('keyword');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('negative_keywords');
+    }
+};


### PR DESCRIPTION
## Summary
- create migrations for Google Ads token, campaign strategies, and negative keywords
- add models `GoogleAdsToken`, `CampaignStrategy`, and `NegativeKeyword`

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/phpunit --filter=none` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556a000b70832e85fa3608b588f0d4