### PR TITLE
Add menu links for active tools

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -15,6 +15,15 @@
                     <x-nav-link href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    <x-nav-link href="{{ route('negative-keywords') }}" :active="request()->routeIs('negative-keywords')">
+                        {{ __('Negative Keywords') }}
+                    </x-nav-link>
+                    <x-nav-link href="{{ route('seo-content') }}" :active="request()->routeIs('seo-content')">
+                        {{ __('SEO Content') }}
+                    </x-nav-link>
+                    <x-nav-link href="{{ route('json-schema') }}" :active="request()->routeIs('json-schema')">
+                        {{ __('JSON Schema') }}
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -141,6 +150,15 @@
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link href="{{ route('dashboard') }}" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('negative-keywords') }}" :active="request()->routeIs('negative-keywords')">
+                {{ __('Negative Keywords') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('seo-content') }}" :active="request()->routeIs('seo-content')">
+                {{ __('SEO Content') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('json-schema') }}" :active="request()->routeIs('json-schema')">
+                {{ __('JSON Schema') }}
             </x-responsive-nav-link>
         </div>
 


### PR DESCRIPTION
## Summary
- add navigation links for Negative Keywords, SEO Content and JSON Schema tools
- mirror links in responsive menu

## Testing
- `php artisan test` *(fails: php not installed)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c64e73d04832e83f1621c7b5b2cd9