### PR TITLE
Implement AI tool routes and components

### DIFF
--- a/app/Livewire/Tools/JsonSchemaGenerator.php
+++ b/app/Livewire/Tools/JsonSchemaGenerator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Livewire\Tools;
+
+use Livewire\Component;
+
+class JsonSchemaGenerator extends Component
+{
+    public string $urls = '';
+    public string $businessInfo = '';
+    public array $results = [];
+
+    public function generate(): void
+    {
+        $this->validate(['urls' => 'required|string']);
+        $lines = preg_split("/\r?\n/", trim($this->urls));
+        $this->results = [];
+        foreach ($lines as $url) {
+            $url = trim($url);
+            if ($url === '') {
+                continue;
+            }
+            $schema = [
+                '@context' => 'https://schema.org',
+                '@type' => 'WebPage',
+                'url' => $url,
+                'name' => 'Schema for ' . $url,
+            ];
+            $this->results[] = [
+                'url' => $url,
+                'schema' => json_encode($schema, JSON_PRETTY_PRINT),
+            ];
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.tools.json-schema-generator');
+    }
+}

--- a/app/Livewire/Tools/NegativeKeywordsManager.php
+++ b/app/Livewire/Tools/NegativeKeywordsManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Livewire\Tools;
+
+use Livewire\Component;
+use App\Models\NegativeKeyword;
+
+class NegativeKeywordsManager extends Component
+{
+    public string $campaignStrategyId = '';
+    public string $adgroupName = '';
+    public string $keywords = '';
+    public $list;
+
+    public function mount(): void
+    {
+        $this->loadKeywords();
+    }
+
+    public function loadKeywords(): void
+    {
+        $this->list = NegativeKeyword::latest()->get();
+    }
+
+    public function addKeywords(): void
+    {
+        $this->validate(['keywords' => 'required|string']);
+        $lines = preg_split("/\r?\n/", trim($this->keywords));
+        foreach ($lines as $keyword) {
+            $keyword = trim($keyword);
+            if ($keyword === '') {
+                continue;
+            }
+            NegativeKeyword::create([
+                'user_id' => auth()->id(),
+                'campaign_strategy_id' => $this->campaignStrategyId ?: null,
+                'adgroup_name' => $this->adgroupName ?: null,
+                'keyword' => $keyword,
+            ]);
+        }
+        $this->keywords = '';
+        $this->loadKeywords();
+    }
+
+    public function render()
+    {
+        return view('livewire.tools.negative-keywords-manager');
+    }
+}

--- a/resources/views/livewire/tools/json-schema-generator.blade.php
+++ b/resources/views/livewire/tools/json-schema-generator.blade.php
@@ -1,0 +1,23 @@
+<div>
+    <form wire:submit.prevent="generate" class="space-y-4">
+        <textarea wire:model="urls" class="w-full border" rows="4" placeholder="One URL per line"></textarea>
+        <textarea wire:model="businessInfo" class="w-full border" rows="3" placeholder="Business info (optional)"></textarea>
+        <x-primary-button type="submit">Generate</x-primary-button>
+    </form>
+
+    @if($results)
+        <table class="mt-6 w-full text-sm">
+            <thead>
+                <tr><th class="text-left">URL</th><th class="text-left">Schema</th></tr>
+            </thead>
+            <tbody>
+                @foreach($results as $row)
+                    <tr class="border-t">
+                        <td class="pr-4 align-top">{{ $row['url'] }}</td>
+                        <td><pre class="whitespace-pre-wrap">{{ $row['schema'] }}</pre></td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+</div>

--- a/resources/views/livewire/tools/negative-keywords-manager.blade.php
+++ b/resources/views/livewire/tools/negative-keywords-manager.blade.php
@@ -1,0 +1,27 @@
+<div>
+    <form wire:submit.prevent="addKeywords" class="space-y-4">
+        <input type="text" wire:model="campaignStrategyId" class="border w-full" placeholder="Campaign Strategy ID" />
+        <input type="text" wire:model="adgroupName" class="border w-full" placeholder="Adgroup Name" />
+        <textarea wire:model="keywords" class="border w-full" rows="4" placeholder="Keywords (one per line)"></textarea>
+        <x-primary-button type="submit">Add</x-primary-button>
+    </form>
+
+    <table class="mt-6 w-full text-sm">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Keyword</th>
+                <th>Adgroup</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($list as $row)
+                <tr class="border-t">
+                    <td>{{ $row->id }}</td>
+                    <td>{{ $row->keyword }}</td>
+                    <td>{{ $row->adgroup_name }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -5,5 +5,12 @@ use App\Http\Controllers\DashboardController;
 Route::middleware(['web','auth:sanctum','verified'])->group(function () {
     Route::get('/dashboard', DashboardController::class)->name('dashboard');
     Route::redirect('/', '/dashboard');
-    Route::get('/seo-content', \App\Livewire\SeoContentManager::class)->name('seo-content');
+    Route::prefix('tools')->group(function () {
+        Route::get('/seo-content', \App\Livewire\SeoContentManager::class)
+            ->name('seo-content');
+        Route::get('/json-schema', \App\Livewire\Tools\JsonSchemaGenerator::class)
+            ->name('json-schema');
+        Route::get('/negative-keywords', \App\Livewire\Tools\NegativeKeywordsManager::class)
+            ->name('negative-keywords');
+    });
 });


### PR DESCRIPTION
## Summary
- add routes for SEO Content, JSON Schema and Negative Keywords tools
- implement `JsonSchemaGenerator` and `NegativeKeywordsManager` Livewire components
- create tool views to manage JSON schema and negative keywords

## Testing
- `php artisan route:list` *(fails: php not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8d1ab6c4832e8d8b431984285d14